### PR TITLE
added test to trap on the post-PowerShell-2.0 operators

### DIFF
--- a/Functions/cmdlet.Tests.ps1
+++ b/Functions/cmdlet.Tests.ps1
@@ -15,7 +15,7 @@ Describe Get-BoundParams {
                     1 { Get-BoundParams     }
                     2 { & (Get-BoundParams) }
                     3 { & (gbpm)            }
-                    4 { & (gbpm -in )       }
+                    4 { & (gbpm -IncludeCommonParameters ) }
                 }
             }
         }
@@ -73,7 +73,7 @@ InModuleScope ToolFoundations {
             {
                 [CmdletBinding()]
                 param()
-                process{&(gbpm -in)}
+                process{&(gbpm -IncludeCommonParameters )}
             }
         }
         AfterAll {

--- a/Functions/cmdlet.ps1
+++ b/Functions/cmdlet.ps1
@@ -14,7 +14,7 @@ The alias gbpm for Get-BoundParams can be use to obtain the current cmdlet's bou
 
 A test for the existence of a parameter in an advanced function then becomes the following:
 
-  if ( 'SomeParameter' -in (&(gbpm)).Keys )
+  if ( (&(gbpm)).Keys -contains 'SomeParameter' )
 
 
 .OUTPUTS
@@ -28,7 +28,7 @@ A scriptblock that evaluates to the cmdlet's bound parameters.
         {
             if
             (
-                'p1' -in (&(gbpm)).Keys -and  # tests existence of parameter
+                (&(gbpm)).Keys -contains 'p1' -and  # tests existence of parameter
                 -not $p1                      # tests value of parameter
             )
             {

--- a/ToolFoundations.Tests.ps1
+++ b/ToolFoundations.Tests.ps1
@@ -118,4 +118,26 @@ Describe 'Style rules' {
             throw "The following files do not end with a newline: `r`n`r`n$($badFiles -join "`r`n")"
         }
     }
+    It 'doesn''t contain new operators.' {
+        $badLines = @(
+            foreach ($file in $files)
+            {
+                $lines = [System.IO.File]::ReadAllLines($file.FullName)
+                $lineCount = $lines.Count
+
+                for ($i = 0; $i -lt $lineCount; $i++)
+                {
+                    if ($lines[$i] -match '( -in | -notin | -shr | -shl )')
+                    {
+                        'File: {0}, Line: {1}' -f $file.FullName, ($i + 1)
+                    }
+                }
+            }
+        )
+
+        if ($badLines.Count -gt 0)
+        {
+            throw "The following $($badLines.Count) lines contain operators introduced after PowerShell 2.0 (e.g. in, notin, shr, shl)  : `r`n`r`n$($badLines -join "`r`n")"
+        }
+    }
 }


### PR DESCRIPTION
PowerShell 2.0 doesn't understand `-in`, `-notin`, `-shr`, and `-shl` operators.  `-in` and `-notin` seem to make their way into this code.  This change is meant to cause earlier failures.  That is, with this change you see failures when you run Invoke-Pester on the dev workstation regardless of PowerShell version.  Otherwise, you might only see the failure at the CI step.
